### PR TITLE
Adding a setting for specifying the service loadBalancerIP

### DIFF
--- a/templates/service.yaml
+++ b/templates/service.yaml
@@ -9,6 +9,9 @@ metadata:
     heritage: {{ .Release.Service }}
 spec:
   type: {{ .Values.service.type }}
+  {{- if  .Values.service.loadBalancerIP }}
+  loadBalancerIP: {{ .Values.service.loadBalancerIP }}
+  {{- end }} 
   ports:
     - port: 8081
       targetPort: 8081

--- a/values.yaml
+++ b/values.yaml
@@ -20,6 +20,7 @@ image:
 
 service:
   type: ClusterIP
+  # loadBalancerIP: 1.2.3.4
 
 ingress:
   enabled: true


### PR DESCRIPTION
This PR makes it possible to specify a loadBalancerIP for services of type=LoadBalancer