### PR TITLE
Allow setting of clusterip in pdns service

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | `image.tag`                | Image tag. | `4.1.2`|
 | `image.pullPolicy`         | Image pull policy | `IfNotPresent` |
 | `service.type`             | Kubernetes service type | `ClusterIP` |
+| `service.clusterip`        | Kubernetes service ClusterIP | `nil` |
 | `ingress.enabled`          | Enables Ingress | `false` |
 | `ingress.annotations`      | Ingress annotations | `{}` |
 | `ingress.path`           | Custom path                       | `/`

--- a/templates/service.yaml
+++ b/templates/service.yaml
@@ -9,6 +9,9 @@ metadata:
     heritage: {{ .Release.Service }}
 spec:
   type: {{ .Values.service.type }}
+  {{- if .Values.service.clusterip }}
+  clusterIP: {{ .Values.service.clusterip | quote }}
+  {{- end }}
   ports:
     - port: 8081
       targetPort: 8081

--- a/values.yaml
+++ b/values.yaml
@@ -20,6 +20,8 @@ image:
 
 service:
   type: ClusterIP
+  # Allows setting explicit ClusterIP address (https://kubernetes.io/docs/concepts/services-networking/service/#choosing-your-own-ip-address)
+  # clusterip: ""
 
 ingress:
   enabled: true


### PR DESCRIPTION
The field `spec.clusterIP` in a kubernetes service is immutable once created, so in order to be able to set this, we need this as a values option.