### PR TITLE
Allow setting of clusterip in pdns service

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | `image.tag`                | Image tag. | `4.1.2`|
 | `image.pullPolicy`         | Image pull policy | `IfNotPresent` |
 | `service.type`             | Kubernetes service type | `ClusterIP` |
+| `service.clusterip`        | Kubernetes service ClusterIP | `nil` |
 | `ingress.enabled`          | Enables Ingress | `false` |
 | `ingress.annotations`      | Ingress annotations | `{}` |
 | `ingress.path`           | Custom path                       | `/`

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | `image.tag`                | Image tag. | `4.1.2`|
 | `image.pullPolicy`         | Image pull policy | `IfNotPresent` |
 | `service.type`             | Kubernetes service type | `ClusterIP` |
-| `service.clusterip`        | Kubernetes service ClusterIP | `nil` |
+| `service.clusterIP`        | Kubernetes service ClusterIP | `nil` |
 | `ingress.enabled`          | Enables Ingress | `false` |
 | `ingress.annotations`      | Ingress annotations | `{}` |
 | `ingress.path`           | Custom path                       | `/`

--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | `pdns.webserver.allowFrom` | PowerDNS webserver allowed IP whitelist |  `0.0.0.0/0`
 | `pdns.dnsupdate.enabled`   | Should DNS UPDATE support be enabled | `no` |
 | `replicaCount`                 | Number of pdns nodes | `1` |
+| `isClusterService`         | Specifies whether chart should be deployed as cluster-service or normal k8s app | `false` |
 | `image.repository`         | Image repository | `psitrax/powerdns` |
 | `image.tag`                | Image tag. | `4.1.2`|
 | `image.pullPolicy`         | Image pull policy | `IfNotPresent` |

--- a/templates/deployment.yaml
+++ b/templates/deployment.yaml
@@ -19,6 +19,9 @@ spec:
         app: {{ template "pdns.name" . }}
         release: {{ .Release.Name }}
     spec:
+      {{- if .Values.isClusterService }}
+      dnsPolicy: Default
+      {{- end }}
       containers:
         - name: {{ .Chart.Name }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"

--- a/templates/service.yaml
+++ b/templates/service.yaml
@@ -9,7 +9,7 @@ metadata:
     heritage: {{ .Release.Service }}
 spec:
   type: {{ .Values.service.type }}
-  {{- if .Values.service.clusterip }}
+  {{- if .Values.service.clusterIP }}
   clusterIP: {{ .Values.service.clusterIP | quote }}
   {{- end }}
   ports:

--- a/templates/service.yaml
+++ b/templates/service.yaml
@@ -10,7 +10,7 @@ metadata:
 spec:
   type: {{ .Values.service.type }}
   {{- if .Values.service.clusterip }}
-  clusterIP: {{ .Values.service.clusterip | quote }}
+  clusterIP: {{ .Values.service.clusterIP | quote }}
   {{- end }}
   ports:
     - port: 8081

--- a/templates/service.yaml
+++ b/templates/service.yaml
@@ -9,6 +9,9 @@ metadata:
     heritage: {{ .Release.Service }}
 spec:
   type: {{ .Values.service.type }}
+  {{- if .Values.service.clusterip }}
+  clusterIP: {{ .Values.service.clusterip | quote }}
+  {{- end }}
   ports:
     - port: 8081
       targetPort: 8081

--- a/values.yaml
+++ b/values.yaml
@@ -12,6 +12,8 @@ pdns:
         enabled: no
 
 replicaCount: 1
+## Specifies whether chart should be deployed as cluster-service or normal k8s app.
+# isClusterService: false
 
 image:
   repository: psitrax/powerdns
@@ -20,7 +22,7 @@ image:
 
 service:
   type: ClusterIP
-  # Allows setting explicit ClusterIP address (https://kubernetes.io/docs/concepts/services-networking/service/#choosing-your-own-ip-address)
+  ## Allows setting explicit ClusterIP address (https://kubernetes.io/docs/concepts/services-networking/service/#choosing-your-own-ip-address)
   # clusterIP: ""
 
 ingress:

--- a/values.yaml
+++ b/values.yaml
@@ -21,7 +21,7 @@ image:
 service:
   type: ClusterIP
   # Allows setting explicit ClusterIP address (https://kubernetes.io/docs/concepts/services-networking/service/#choosing-your-own-ip-address)
-  # clusterip: ""
+  # clusterIP: ""
 
 ingress:
   enabled: true

--- a/values.yaml
+++ b/values.yaml
@@ -20,6 +20,8 @@ image:
 
 service:
   type: ClusterIP
+  # Allows setting explicit ClusterIP address (https://kubernetes.io/docs/concepts/services-networking/service/#choosing-your-own-ip-address)
+  # clusterip: ""
 
 ingress:
   enabled: true


### PR DESCRIPTION
The field `spec.clusterIP` in a kubernetes service is immutable once created, so in order to be able to set this, we need this as a values option.