### PR TITLE
Allow service discovery of mariadb service by env

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | `mariadb.persistence.storageClass`           | PVC Storage Class                          | `nil` (uses alpha storage class annotation)                |
 | `mariadb.persistence.accessMode`             | PVC Access Mode                            | `ReadWriteOnce`                                            |
 | `mariadb.persistence.size`                   | PVC Storage Request                        | `2Gi`   |
+| `mariadb.serviceDiscovery`           | Discovery of mariadb service. One of: dns, env         | `dns`   |
 
 
 # Modifications to nginx-ingress

--- a/templates/deployment.yaml
+++ b/templates/deployment.yaml
@@ -27,7 +27,11 @@ spec:
           args: ["--api={{ .Values.pdns.api.enabled }}", "--api-key={{ .Values.pdns.api.key }}", "--webserver=yes", "--webserver-port=8081", "--webserver-address=0.0.0.0", "--webserver-allow-from={{ .Values.pdns.webserver.allowFrom }}", "--slave=yes", "--dnsupdate={{ .Values.pdns.dnsupdate.enabled }}"]
           env:
               - name: MYSQL_HOST
+              {{- if or (empty .Values.mariadb.serviceDiscovery) (eq .Values.mariadb.serviceDiscovery "dns") }}
                 value: {{ template "mariadb.fullname" . }}
+              {{- else if eq .Values.mariadb.serviceDiscovery "env" }}
+                value: {{ (include "mariadb.fullname" .) | replace "-" "_" | upper | printf "$(%s_SERVICE_HOST)" }}
+              {{- end }}
               - name: MYSQL_USER
                 value: "root"
                 value: {{ .Values.mariadb.mariadbUser | quote }}

--- a/values.yaml
+++ b/values.yaml
@@ -99,3 +99,9 @@ mariadb:
     # storageClass: "-"
     accessMode: ReadWriteOnce
     size: 2Gi
+
+  ## How the MariaDB host address is discovered:
+  ## dns: using service name of mariadb, requires working dns in cluster (default)
+  ## env: using service ip of mariadb by using the exposed env of the mariadb service
+  serviceDiscovery: dns
+  


### PR DESCRIPTION
If you don't have dns (yet) available in your cluster, allow an option to fall back using the exported env of the mariadb service