### PR TITLE
templates/deployment.yaml: remove redundant volumes

### DIFF
--- a/templates/deployment.yaml
+++ b/templates/deployment.yaml
@@ -76,7 +76,3 @@ spec:
       tolerations:
 {{ toYaml . | indent 8 }}
     {{- end }}
-      volumes:
-      - name: powerdns-api-key
-        secret:
-          secretName: powerdns-api-key


### PR DESCRIPTION
16ae52a673ba8d5a6d7dcee8739878cf0ee2b948 added secret volume to use it
to load API key from secret into env variable. Turns out volume is not
needed for that, so it should be removed, as it's not needed.

Signed-off-by: Mateusz Gozdek <mateusz@kinvolk.io>