### PR TITLE
enable support for static load balancer ips in service

### DIFF
--- a/Chart.yaml
+++ b/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 appVersion: "1.0"
 description: A Helm chart to deploy PowerDNS to Kubernetes
 name: pdns
-version: 0.1.1
+version: 0.1.2

--- a/Chart.yaml
+++ b/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 appVersion: "1.0"
 description: A Helm chart to deploy PowerDNS to Kubernetes
 name: pdns
-version: 0.1.0
+version: 0.1.1

--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | `image.tag`                | Image tag. | `4.1.2`|
 | `image.pullPolicy`         | Image pull policy | `IfNotPresent` |
 | `service.type`             | Kubernetes service type | `ClusterIP` |
+| `service.loadBalancerIP`             | Kubernetes static IP for service | `` |
 | `ingress.enabled`          | Enables Ingress | `false` |
 | `ingress.annotations`      | Ingress annotations | `{}` |
 | `ingress.path`           | Custom path                       | `/`

--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | `image.pullPolicy`         | Image pull policy | `IfNotPresent` |
 | `service.type`             | Kubernetes service type | `ClusterIP` |
 | `service.loadBalancerIP`             | Kubernetes static IP for service | `` |
+| `service.annotations`             | Kubernetes annotations for service | `` |
 | `ingress.enabled`          | Enables Ingress | `false` |
 | `ingress.annotations`      | Ingress annotations | `{}` |
 | `ingress.path`           | Custom path                       | `/`

--- a/requirements.yaml
+++ b/requirements.yaml
@@ -1,5 +1,5 @@
 dependencies:
 - name: mariadb
-  version: 2.1.1
-  repository: https://kubernetes-charts.storage.googleapis.com/
+  version: 7.4.2
+  repository: https://charts.bitnami.com/bitnami
   condition: mariadb.enabled

--- a/templates/deployment.yaml
+++ b/templates/deployment.yaml
@@ -1,4 +1,4 @@
-apiVersion: apps/v1beta2
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ template "pdns.fullname" . }}

--- a/templates/ingress.yaml
+++ b/templates/ingress.yaml
@@ -32,7 +32,7 @@ spec:
         paths:
           - path: {{ $ingressPath }}
             backend:
-              serviceName: {{ $fullName }}
+              serviceName: {{ $fullName }}-tcp
               servicePort: api
   {{- end }}
 {{- end }}

--- a/templates/service-tcp.yaml
+++ b/templates/service-tcp.yaml
@@ -1,12 +1,16 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ template "pdns.fullname" . }}
+  name: {{ template "pdns.fullname" . }}-tcp
   labels:
     app: {{ template "pdns.name" . }}
     chart: {{ template "pdns.chart" . }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
+{{- with .Values.service.annotations }}
+  annotations:
+{{ toYaml . | indent 4 }}
+{{- end }}
 spec:
   type: {{ .Values.service.type }}
   {{- if .Values.service.loadBalancerIP }}
@@ -17,10 +21,6 @@ spec:
       targetPort: 8081
       protocol: TCP
       name: api
-    - port: 53
-      targetPort: 53
-      protocol: UDP
-      name: dns-udp
     - port: 53
       targetPort: 53
       protocol: TCP

--- a/templates/service-udp.yaml
+++ b/templates/service-udp.yaml
@@ -1,0 +1,26 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ template "pdns.fullname" . }}-udp
+  labels:
+    app: {{ template "pdns.name" . }}
+    chart: {{ template "pdns.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+{{- with .Values.service.annotations }}
+  annotations:
+{{ toYaml . | indent 4 }}
+{{- end }}
+spec:
+  type: {{ .Values.service.type }}
+  {{- if .Values.service.loadBalancerIP }}
+  loadBalancerIP: {{ .Values.service.loadBalancerIP }}
+  {{- end }}
+  ports:
+    - port: 53
+      targetPort: 53
+      protocol: UDP
+      name: dns-udp
+  selector:
+    app: {{ template "pdns.name" . }}
+    release: {{ .Release.Name }}

--- a/templates/service.yaml
+++ b/templates/service.yaml
@@ -9,6 +9,9 @@ metadata:
     heritage: {{ .Release.Service }}
 spec:
   type: {{ .Values.service.type }}
+  {{- if .Values.service.loadBalancerIP }}
+  loadBalancerIP: {{ .Values.service.loadBalancerIP }}
+  {{- end }}
   ports:
     - port: 8081
       targetPort: 8081

--- a/values.yaml
+++ b/values.yaml
@@ -21,6 +21,7 @@ image:
 service:
   type: ClusterIP
   loadBalancerIP:
+  annotations:
 
 ingress:
   enabled: true

--- a/values.yaml
+++ b/values.yaml
@@ -20,6 +20,7 @@ image:
 
 service:
   type: ClusterIP
+  loadBalancerIP:
 
 ingress:
   enabled: true


### PR DESCRIPTION
Allows for the pre-designation of a loadbalancerIP on a ClusterIP service type.
Signed-off-by: Ryan Holt <ryan@ryanholt.net>